### PR TITLE
hide stack trace on exit

### DIFF
--- a/ldndc2nc/__init__.py
+++ b/ldndc2nc/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from logging import NullHandler
 from logging.handlers import RotatingFileHandler
 
@@ -13,6 +14,13 @@ except importlib_metadata.PackageNotFoundError:
     # package is not installed
     pass
 
+
+# silent exit hook
+def excepthook(exc_type, exc_value, exc_traceback):
+    print("Exit")
+
+
+sys.excepthook = excepthook
 
 logging.getLogger(__name__).addHandler(NullHandler())
 

--- a/ldndc2nc/cli.py
+++ b/ldndc2nc/cli.py
@@ -59,8 +59,7 @@ class RangeAction(argparse.Action):
         if is_valid_year_range(s):
             setattr(namespace, self.dest, range(int(s[0]), int(s[-1]) + 1))
         else:
-            log.critical("No valid range: %s" % values)
-            exit(1)
+            raise ValueError(log.critical(f"No valid range: {values}"))
 
 
 class MultiArgsAction(argparse.Action):
@@ -75,8 +74,7 @@ class MultiArgsAction(argparse.Action):
         if len(s) == self._nsegs:
             setattr(namespace, self.dest, tuple(s))
         else:
-            log.critical("Syntax error in %s" % option_string)
-            exit(1)
+            raise SyntaxError(log.critical("Syntax error in %s" % option_string))
 
 
 class CustomFormatter(
@@ -183,7 +181,8 @@ def cli():
     log.debug("ldndc2nc called at: %s" % dt.datetime.now())
 
     if args.storeconfig and (args.config is None):
-        log.critical("Option -S requires that you pass a file with -c.")
-        exit(1)
+        raise ValueError(
+            log.critical("Option -S requires that you pass a file with -c.")
+        )
 
     return args

--- a/ldndc2nc/config_handler.py
+++ b/ldndc2nc/config_handler.py
@@ -65,15 +65,14 @@ def get_section(self, section):
         try:
             section_data = self.cfg.get(section, self.cfg.get(section.lower()))
         except KeyError:
-            log.critical(
+            log.warning(
                 f"Section <{section.lower()}> not found in cfg file {self.file_path}"
             )
-            log.critical(
-                f"The following sections are present: {list(self.cfg.keys())}."
-            )
+            log.warning(f"The following sections are present: {list(self.cfg.keys())}.")
     else:
-        log.critical(f"Section {section.lower()} is not a valid section")
-        raise RuntimeError
+        raise RuntimeError(
+            log.critical(f"Section {section.lower()} is not a valid section")
+        )
     return section_data
 
 


### PR DESCRIPTION
Hide stack trace and raise errors instead of plain exit(1) commands if critical.

Not that this masks any stack trace output - so if you expect to see crashed this needs to be disabled in __init__.py.

In the future, this should probably be a cli flag (-v)

Closes #15 